### PR TITLE
fix variable name in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Usage
     Taxa(tx1, tx2, tx3)
 
     from pytaxa import Hierarchy
-    out = Hierarchy(tx1, tx2, tx)
+    out = Hierarchy(tx1, tx2, tx3)
     out.taxa
     out.ranklist
     out.all_empty()


### PR DESCRIPTION
## Description
fix typo

## Related Issue
none

## Example
Example works now: it didn't before:
```
>>> out = Hierarchy(tx1, tx2, tx3)
>>> out.taxa
[<Taxon>
  name: Poaceae
  rank: family
  id: 4479
  authority: , <Taxon>
  name: Poa
  rank: genus
  id: 12345
  authority: L., <Taxon>
  name: Poa annua
  rank: species
  id: 93036
  authority: ]
```

