### PR TITLE
Mccalluc/test hierarchy

### DIFF
--- a/test/test_Hierarchy.py
+++ b/test/test_Hierarchy.py
@@ -28,7 +28,23 @@ def test_Hierarchy():
     assert isinstance(x.ranklist, list)
     assert isinstance(x.xlen, int)
     assert 3 == len(x)
-    assert x == x.pop()
+    assert repr(x) == repr(x.pop())  # .pop() with no args is a no-op.
+
+    x.pop(ranks='FAKE')
+    assert 3 == len(x)
+    x.pop(ranks='genus')
+    assert 2 == len(x)
+
+    x.pop(names='FAKE')
+    assert 2 == len(x)
+    x.pop(names='Poaceae')
+    assert 1 == len(x)
+
+    x.pop(ids='FAKE')
+    assert 1 == len(x)
+    x.pop(ids=93036)
+    assert 0 == len(x)
+
 
 
 def test_Hierarchy_empty():

--- a/test/test_Hierarchy.py
+++ b/test/test_Hierarchy.py
@@ -28,6 +28,8 @@ def test_Hierarchy():
     assert isinstance(x.ranklist, list)
     assert isinstance(x.xlen, int)
     assert 3 == len(x)
+    assert x == x.pop()
+
 
 def test_Hierarchy_empty():
     "Hierarchy - empty"
@@ -40,6 +42,8 @@ def test_Hierarchy_empty():
     assert x.ranklist is None
     assert isinstance(x.xlen, int)
     assert 1 == len(x)
+    with pytest.raises(ValueError):
+        x.pop()
 
 def test_print_taxon():
     assert 'empty' == Hierarchy.print_taxon(Taxon())

--- a/test/test_Hierarchy.py
+++ b/test/test_Hierarchy.py
@@ -40,3 +40,7 @@ def test_Hierarchy_empty():
     assert x.ranklist is None
     assert isinstance(x.xlen, int)
     assert 1 == len(x)
+
+def test_print_taxon():
+    assert 'empty' == Hierarchy.print_taxon(Taxon())
+    assert 'Poa annua / species / 93036' == Hierarchy.print_taxon(tx3)

--- a/test/test_Hierarchy.py
+++ b/test/test_Hierarchy.py
@@ -1,4 +1,5 @@
 """Tests for Hierarchy"""
+from copy import copy
 import pytest
 from pytaxa import constructors as cs
 from pytaxa import Taxon,Hierarchy
@@ -28,6 +29,27 @@ def test_Hierarchy():
     assert isinstance(x.ranklist, list)
     assert isinstance(x.xlen, int)
     assert 3 == len(x)
+
+def test_Hierarchy_pick():
+    x = Hierarchy(tx3, tx1, tx2)
+
+    assert 0 == len(copy(x).pick())
+    assert 1 == len(copy(x).pick(ranks='family'))
+    assert 1 == len(copy(x).pick(ranks='genus'))
+    assert 1 == len(copy(x).pick(ranks='species'))
+    assert 2 == len(copy(x).pick(names='Poaceae'))
+    assert 1 == len(copy(x).pick(names='Poa'))
+    assert 2 == len(copy(x).pick(names='Poa annua'))
+    assert 1 == len(copy(x).pick(ids=4479))
+    assert 1 == len(copy(x).pick(ids=12345))
+    assert 1 == len(copy(x).pick(ids=93036))
+
+    with pytest.raises(ValueError):
+        Hierarchy().pick()
+
+def test_Hierarchy_pop():
+    x = Hierarchy(tx3, tx1, tx2)
+
     assert repr(x) == repr(x.pop())  # .pop() with no args is a no-op.
 
     x.pop(ranks='FAKE')
@@ -44,8 +66,6 @@ def test_Hierarchy():
     assert 1 == len(x)
     x.pop(ids=93036)
     assert 0 == len(x)
-
-
 
 def test_Hierarchy_empty():
     "Hierarchy - empty"


### PR DESCRIPTION
## Description
Improve test coverage on `Hierarchy`.

## Related Issue
Starting on #5

## Comments
- With the plural kwargs, I would expect to be able to pass in arrays... I'm not sure if that would make sense?
- Is the behavior with pick by name what you expect?
- These lines in `pop()` don't make sense to me:
```python
      alldat = [ranks, names, ids]
      if (len(alldat) == 0):
        raise ValueError("one of 'ranks', 'names', or 'ids' must be used")
      
      taxa_rks = [z.rank.get('name') for z in self.taxa]
      taxa_nms = [z.name.get('name') for z in self.taxa]
      taxa_ids = [z.id.get('id') for z in self.taxa]
```
- `len(alldat)` will always be 3:
```python
>>> len([None, None, None])
3
>>> len([[], [], []])
3
```
- The `taxa_*` variables are never used.

