### PR TITLE
"not any" is the right logic

### DIFF
--- a/pytaxa/taxa/hierarchy.py
+++ b/pytaxa/taxa/hierarchy.py
@@ -154,14 +154,9 @@ class Hierarchy(object):
       """
       if self.all_empty():
         raise ValueError("no taxa found")
-      
-      alldat = [ranks, names, ids]
-      if (len(alldat) == 0):
+
+      if (not any([ranks, names, ids])):
         raise ValueError("one of 'ranks', 'names', or 'ids' must be used")
-      
-      taxa_rks = [z.rank.get('name') for z in self.taxa]
-      taxa_nms = [z.name.get('name') for z in self.taxa]
-      taxa_ids = [z.id.get('id') for z in self.taxa]
 
       self.taxa = [w for w in self.taxa if 
         w.rank.get('name') != ranks and 
@@ -190,9 +185,8 @@ class Hierarchy(object):
       """
       if self.all_empty():
         raise ValueError("no taxa found")
-      
-      alldat = [ranks, names, ids]
-      if (len(alldat) == 0):
+
+      if (not any([ranks, names, ids])):
         raise ValueError("one of 'ranks', 'names', or 'ids' must be used")
       
       self.taxa = [

--- a/test/test_Hierarchy.py
+++ b/test/test_Hierarchy.py
@@ -33,7 +33,8 @@ def test_Hierarchy():
 def test_Hierarchy_pick():
     x = Hierarchy(tx3, tx1, tx2)
 
-    assert 0 == len(copy(x).pick())
+    with pytest.raises(ValueError):
+        copy(x).pick()
     assert 1 == len(copy(x).pick(ranks='family'))
     assert 1 == len(copy(x).pick(ranks='genus'))
     assert 1 == len(copy(x).pick(ranks='species'))
@@ -50,7 +51,8 @@ def test_Hierarchy_pick():
 def test_Hierarchy_pop():
     x = Hierarchy(tx3, tx1, tx2)
 
-    assert repr(x) == repr(x.pop())  # .pop() with no args is a no-op.
+    with pytest.raises(ValueError):
+        x.pop()
 
     x.pop(ranks='FAKE')
     assert 3 == len(x)


### PR DESCRIPTION
## Description
Correct behavior for input validation; remove unused code.

## Related Issue
Follow up to PR #6

## Example
`h.pick()` and `h.pop()` without arguments now fail.

