### PR TITLE
Allow lists if kwarg name is plural

### DIFF
--- a/pytaxa/taxa/hierarchy.py
+++ b/pytaxa/taxa/hierarchy.py
@@ -136,7 +136,7 @@ class Hierarchy(object):
       """
       return all([z.is_empty() for z in self.taxa])
 
-    def pop(self, ranks = None, names = None, ids = None):
+    def pop(self, ranks = [], names = [], ids = []):
       """
       Pop out certain taxa by ranks, names, or ids
 
@@ -163,10 +163,17 @@ class Hierarchy(object):
       taxa_nms = [z.name.get('name') for z in self.taxa]
       taxa_ids = [z.id.get('id') for z in self.taxa]
 
+      if type(ranks) == str:
+        ranks = [ranks]
+      if type(names) == str:
+        names = [names]
+      if type(ids) == int:
+        ids = [ids]
+
       self.taxa = [w for w in self.taxa if 
-        w.rank.get('name') != ranks and 
-        w.name.get('name') != names and 
-        w.id.get('id') != ids]
+        w.rank.get('name') not in ranks and
+        w.name.get('name') not in names and
+        w.id.get('id') not in ids]
 
       self.taxa = self.__sort_hierarchy(self.taxa)
       self.xlen = len(self.taxa)

--- a/test/test_Hierarchy.py
+++ b/test/test_Hierarchy.py
@@ -59,12 +59,12 @@ def test_Hierarchy_pop():
 
     x.pop(names='FAKE')
     assert 2 == len(x)
-    x.pop(names='Poaceae')
+    x.pop(names=['FAKE', 'Poaceae'])
     assert 1 == len(x)
 
-    x.pop(ids='FAKE')
+    x.pop(ids=0)
     assert 1 == len(x)
-    x.pop(ids=93036)
+    x.pop(ids=[0, 93036])
     assert 0 == len(x)
 
 def test_Hierarchy_empty():


### PR DESCRIPTION
## Description
background:

mccalluc:
>    With the plural kwargs, I would expect to be able to pass in arrays... I'm not sure if that would make sense?

sckott:
> right. it would be nice if it's flexible so that it can take Taxon objects like Hierarchy(x, x, x) or an array like Hierarchy([x, x, x])

Sorry, I didn't explain that well: I was talking about the kwargs to pop and pick: it feels strange that they are plural, but then they just accept a string. I you want to support passing lists, it would probably be less confusing to only support lists, but if you want it to be flexible, this is one way to do it. (If you do like this, the same work still needs to be done for `post`.)

## Related Issue
Follow up to #6

## Example
from the tests:
```python
x.pop(ranks='genus')
x.pop(names=['FAKE', 'Poaceae'])
```