### PR TITLE
Dict serialization order is not stable across versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,9 @@ Usage
 .. code-block:: python
 
     >>> from pytaxa import constructors as cs
-    >>> cs.taxon_name("Poa")
-    {'name': 'Poa', 'database': None}
+    >>> tn = cs.taxon_name("Poa")
+    >>> tn['name']
+    'Poa'
 
     >>> from pytaxa import Taxon
     >>> x = Taxon(None)


### PR DESCRIPTION
Just output one value at a time and order does not matter.

## Related Issue
Follow up to #14